### PR TITLE
Feature/rsd 2 fix carousel rendering

### DIFF
--- a/config/sync/core.entity_view_display.node.page.full.yml
+++ b/config/sync/core.entity_view_display.node.page.full.yml
@@ -91,10 +91,10 @@ third_party_settings:
             uuid: b15e7cfd-e6e0-486f-ac90-7a55832be598
             region: top
             configuration:
+              id: 'field_block:node:page:field_image'
               label_display: '0'
               context_mapping:
                 entity: layout_builder.entity
-              id: 'field_block:node:page:field_image'
               formatter:
                 type: image
                 label: hidden

--- a/config/sync/slick.optionset.4_thumbnails.yml
+++ b/config/sync/slick.optionset.4_thumbnails.yml
@@ -1,0 +1,18 @@
+uuid: de31ddaa-3c1e-479e-babf-b3bbf2151429
+langcode: en
+status: true
+dependencies: {  }
+id: 4_thumbnails
+name: 4_thumbnails
+weight: 0
+label: '4 thumbnails'
+group: main
+skin: grid
+breakpoints: 0
+optimized: true
+options:
+  options__active_tab: edit-options-settings
+  settings:
+    lazyLoad: ondemand
+    slidesPerRow: 4
+    slidesToShow: 4

--- a/config/sync/slick.optionset.4_thumbnails.yml
+++ b/config/sync/slick.optionset.4_thumbnails.yml
@@ -8,11 +8,27 @@ weight: 0
 label: '4 thumbnails'
 group: main
 skin: grid
-breakpoints: 0
+breakpoints: 2
 optimized: true
 options:
-  options__active_tab: edit-options-settings
+  options__active_tab: edit-options-responsives
   settings:
     lazyLoad: ondemand
     slidesPerRow: 4
     slidesToShow: 4
+  responsives:
+    responsive:
+      -
+        breakpoint: 480
+        unslick: false
+        settings:
+          slidesPerRow: 2
+          slidesToShow: 2
+          waitForAnimate: false
+      -
+        breakpoint: 768
+        unslick: false
+        settings:
+          slidesPerRow: 3
+          slidesToShow: 3
+          waitForAnimate: false

--- a/config/sync/slick.optionset.x_vtabs.yml
+++ b/config/sync/slick.optionset.x_vtabs.yml
@@ -25,7 +25,7 @@ options:
     mouseWheel: true
     slidesToShow: 7
     slidesToScroll: 3
-    edgeFriction: 1
+    edgeFriction: !!float 1
     touchMove: false
     vertical: true
     verticalSwiping: true

--- a/config/sync/views.view.sd38_feature_pages.yml
+++ b/config/sync/views.view.sd38_feature_pages.yml
@@ -367,7 +367,7 @@ display:
           vanilla: false
           layout: ''
           cache: 0
-          skin: ''
+          skin: default
           style: grid
           grid: ''
           grid_medium: ''

--- a/config/sync/views.view.sd38_feature_pages.yml
+++ b/config/sync/views.view.sd38_feature_pages.yml
@@ -9,7 +9,7 @@ dependencies:
   module:
     - image
     - node
-    - semanticviews
+    - slick_views
     - user
 id: sd38_feature_pages
 label: 'SD38 Feature Pages'
@@ -210,7 +210,7 @@ display:
           hide_alter_empty: true
           text: view
           output_url_as_text: true
-          absolute: false
+          absolute: true
         nothing:
           id: nothing
           table: views
@@ -225,7 +225,7 @@ display:
             alter_text: true
             text: '<div><a href="{{ view_node }}" title="{{ title }}">{{ field_page_thumbnail_image }}</a></div>'
             make_link: false
-            path: ''
+            path: view_node
             absolute: false
             external: false
             replace_spaces: false
@@ -264,7 +264,7 @@ display:
         type: some
         options:
           offset: 0
-          items_per_page: 4
+          items_per_page: 0
       exposed_form:
         type: basic
         options:
@@ -350,27 +350,52 @@ display:
             default_group_multiple: {  }
             group_items: {  }
       style:
-        type: semanticviews_style
+        type: slick
         options:
-          grouping: {  }
-          group:
-            element_type: h2
-            attributes: class|title
-          list:
-            element_type: div
-            attributes: class|row
-          row:
-            element_type: div
-            attributes: 'class|col-12 col-md-3'
-            last_every_nth: ''
-            first_class: ''
-            last_class: ''
-            striping_classes: ''
+          caption:
+            nothing: nothing
+            field_page_thumbnail_image: '0'
+            title: '0'
+            view_node: '0'
+          optionset: 4_thumbnails
+          class: ''
+          id: ''
+          image: ''
+          link: ''
+          overlay: ''
+          title: ''
+          vanilla: false
+          layout: ''
+          cache: 0
+          skin: ''
+          style: grid
+          grid: ''
+          grid_medium: ''
+          grid_small: ''
+          overridables:
+            arrows: '0'
+            autoplay: '0'
+            dots: '0'
+            draggable: '0'
+            infinite: '0'
+            mouseWheel: '0'
+            randomize: '0'
+            variableWidth: '0'
+          thumbnail: ''
+          optionset_thumbnail: ''
+          skin_thumbnail: ''
+          thumbnail_caption: ''
+          thumbnail_effect: ''
+          thumbnail_position: ''
+          override: false
+          preserve_keys: false
+          visible_items: null
       row:
         type: fields
         options:
           default_field_elements: true
-          inline: {  }
+          inline:
+            nothing: nothing
           separator: ''
           hide_empty: false
       query:

--- a/web/themes/rsd_district/css/style.css
+++ b/web/themes/rsd_district/css/style.css
@@ -373,7 +373,6 @@ button.navbar-toggler {
 	overflow: hidden;
 	box-shadow: 0 7px 25px 0 rgba(0,0,0,0.03),0 4px 12px 0 rgba(0,0,0,0.03);
 	border: none !important;
-	margin-bottom: 30px;
 }
 
 .view-sd38-feature-pages .card .card-link-text {
@@ -398,6 +397,16 @@ button.navbar-toggler {
 
 .view-sd38-feature-pages img:hover {
 	opacity: 1;
+}
+
+.view-sd38-feature-pages .slick-wrap {
+	margin-bottom: 30px;
+}
+
+@media screen and (max-width: 1023px) {
+	.view-sd38-feature-pages .slide__caption {
+		padding: 10px;
+	}	
 }
 
 .card-deck .col, .card-deck .col-1, .card-deck .col-10, .card-deck .col-11, .card-deck .col-12, .card-deck .col-2, .card-deck .col-3, .card-deck .col-4, .card-deck .col-5, .card-deck .col-6, .card-deck .col-7, .card-deck .col-8, .card-deck .col-9, .card-deck .col-auto, .card-deck .col-lg, .card-deck .col-lg-1, .card-deck .col-lg-10, .card-deck .col-lg-11, .card-deck .col-lg-12, .card-deck .col-lg-2, .card-deck .col-lg-3, .card-deck .col-lg-4, .card-deck .col-lg-5, .card-deck .col-lg-6, .card-deck .col-lg-7, .card-deck .col-lg-8, .card-deck .col-lg-9, .card-deck .col-lg-auto, .card-deck .col-md, .card-deck .col-md-1, .card-deck .col-md-10, .card-deck .col-md-11, .card-deck .col-md-12, .card-deck .col-md-2, .card-deck .col-md-3, .card-deck .col-md-4, .card-deck .col-md-5, .card-deck .col-md-6, .card-deck .col-md-7, .card-deck .col-md-8, .card-deck .col-md-9, .card-deck .col-md-auto, .card-deck .col-sm, .card-deck .col-sm-1, .card-deck .col-sm-10, .card-deck .col-sm-11, .card-deck .col-sm-12, .card-deck .col-sm-2, .card-deck .col-sm-3, .card-deck .col-sm-4, .card-deck .col-sm-5, .card-deck .col-sm-6, .card-deck .col-sm-7, .card-deck .col-sm-8, .card-deck .col-sm-9, .card-deck .col-sm-auto, .card-deck .col-xl, .card-deck .col-xl-1, .card-deck .col-xl-10, .card-deck .col-xl-11, .card-deck .col-xl-12, .card-deck .col-xl-2, .card-deck .col-xl-3, .card-deck .col-xl-4, .card-deck .col-xl-5, .card-deck .col-xl-6, .card-deck .col-xl-7, .card-deck .col-xl-8, .card-deck .col-xl-9, .card-deck .col-xl-auto {
@@ -1784,6 +1793,19 @@ body.edweek .edweek.day5 .event-title {
 #slick-grid-slider .list-group-item {
 	background: unset !important;
 	border: unset !important;
+}
+
+/* Prevent recalculation error on the slider if the parent has display: flex */
+.slick-wrap {
+	width: 100%;
+}
+
+.slick-prev {
+	left: -10px;
+}
+
+.slick-next {
+	right: -10px;
 }
 
 /*** Bootstrap Carousel Styles ***/

--- a/web/themes/rsd_district/templates/slick-wrapper.html.twig
+++ b/web/themes/rsd_district/templates/slick-wrapper.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a slick wrapper.
+ *
+ * Available variables:
+ * - items: A list of items containing main and thumbnail of slick.html.twig
+ *   which can be re-position using option Thumbnail position.
+ * - attributes: HTML attributes to be applied to the list.
+ * - settings: An array containing the given settings.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'slick-wrapper',
+    settings.nav ? 'slick-wrapper--asnavfor',
+    settings.skin ? 'slick-wrapper--' ~ settings.skin|clean_class,
+    settings.skin_thumbnail ? 'slick-wrapper--' ~ settings.skin_thumbnail|clean_class,
+    settings.vertical ? 'slick-wrapper--v',
+    settings.vertical_tn ? 'slick-wrapper--v-tn',
+    settings.thumbnail_position ? 'slick-wrapper--tn-' ~ settings.thumbnail_position|clean_class,
+    'over' in settings.thumbnail_position ? 'slick-wrapper--tn-overlay',
+    'over' in settings.thumbnail_position ? 'slick-wrapper--tn-' ~ settings.thumbnail_position|replace({ 'over-' : '' })
+  ]
+%}
+<div class="slick-wrap">
+{% if settings.nav %}
+  <div{{ attributes.addClass(classes)|without('id') }}>
+    {{ items }}
+  </div>
+{% else %}
+  {{ items }}
+{% endif %}
+</div>


### PR DESCRIPTION
Fixes featured pages thumbnail carousel on the homepage:

- Create new Slick optionset called `4 thumbnails` and add responsive behaviour
- Update SD38 Feature Pages view to use new slick optionset and set theme.
- Add CSS style fixes.

Note: Slick default option set (desktop view) is set to show 4 items at a time. So if you only have 4 items, you won't be able to scroll through since there's nothing further to scroll to. If you resize to a smaller viewport, I've set it to show 3 and 2 items where the prev/next functionality will appear. If you want to be able to scroll through the nav items on desktop view, you should have a minimum of 5 thumbnails.