### PR TITLE
Updates to search_api server config for Plaform.sh hosted solr

### DIFF
--- a/config/sync/search_api.server.solr_search.yml
+++ b/config/sync/search_api.server.solr_search.yml
@@ -38,15 +38,15 @@ backend_config:
   server_prefix: ''
   domain: generic
   environment: default
-  connector: basic_auth
+  connector: standard
   connector_config:
     scheme: http
-    host: solr
-    port: 8983
+    host: solrsearch.internal
+    port: 8080
     path: /
-    core: dev
-    timeout: 5
-    index_timeout: 5
+    core: maincore
+    timeout: 10
+    index_timeout: 10
     optimize_timeout: 10
     finalize_timeout: 30
     skip_schema_check: false
@@ -56,8 +56,6 @@ backend_config:
     jmx: false
     jts: false
     solr_install_dir: /opt/solr
-    username: solr
-    password: SolrRocks
   optimize: false
   fallback_multiple: false
   disabled_field_types: {  }


### PR DESCRIPTION
This updates search_api config for the solr search server to use the Platform.sh hosted service.